### PR TITLE
adding VS Code extension manifest with start command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "productivity-tracker",
+    "displayName": "Productivity Tracker",
+    "description": "Track coding activity & auto-commit summaries to private repo.",
+    "version": "0.0.1",
+    "publisher": "yourname",
+    "engines": { "vscode": "^1.80.0" },
+    "activationEvents": ["onCommand:extension.startTracker"],
+    "main": "./out/extension.js",
+    "contributes": {
+      "commands": [
+        { "command": "extension.startTracker", "title": "Start Tracker" }
+      ]
+    }
+  }
+  


### PR DESCRIPTION
- Add basic VS Code extension manifest
- placeholder for Start Tracker command