### PR TITLE
added idle mode to fetch article and commit as markdown

### DIFF
--- a/tracker/articleFetcher.js
+++ b/tracker/articleFetcher.js
@@ -1,0 +1,24 @@
+const Parser = require('rss-parser');
+const fs = require('fs');
+const parser = new Parser();
+
+async function addArticle() {
+  let feed = await parser.parseURL('https://www.freecodecamp.org/news/rss/');
+  const first = feed.items[0];
+  const filename = `articles/article-${Date.now()}.md`;
+  fs.writeFileSync(filename, `# ${first.title}\n\n${first.link}`);
+  console.log(`Added article: ${first.title}`);
+}
+
+module.exports = { addArticle };
+
+
+// This code fetches the latest article from freeCodeCamp's RSS feed and saves it as a markdown file.
+const { addArticle } = require('./articleFetcher');
+// inside cron job
+if (changeBuffer.length === 0) {
+  await addArticle();
+  await git.add('.');
+  await git.commit(`docs: add new tech article`);
+}
+


### PR DESCRIPTION
adding idle mode to inject new tech article when no changes are identified 

- Fetch random tech (need to change it to choice based) article from RSS

- Summarize (placeholder for GPT summarization process)

- Add as new `.md` file in `articles` folder